### PR TITLE
Refactor sheet order logic and update GoogleSheetManager API

### DIFF
--- a/RaptorSheets.Core.Tests/Unit/Helpers/EntitySheetOrderHelperTests.cs
+++ b/RaptorSheets.Core.Tests/Unit/Helpers/EntitySheetOrderHelperTests.cs
@@ -61,10 +61,10 @@ public class EntitySheetOrderHelperTests
 
         // Assert
         Assert.Equal(4, sheetOrder.Count);
-        Assert.Equal("Trips", sheetOrder[0]);    // Order 0
-        Assert.Equal("Shifts", sheetOrder[1]);   // Order 1
-        Assert.Equal("Expenses", sheetOrder[2]); // Order 2
-        Assert.Equal("Setup", sheetOrder[3]);    // Order 3
+        Assert.Equal("Trips", sheetOrder[0]);    // First property
+        Assert.Equal("Expenses", sheetOrder[1]); // Second property
+        Assert.Equal("Shifts", sheetOrder[2]);   // Third property
+        Assert.Equal("Setup", sheetOrder[3]);    // Fourth property
     }
 
     [Fact]

--- a/RaptorSheets.Core/Attributes/ColumnOrderAttribute.cs
+++ b/RaptorSheets.Core/Attributes/ColumnOrderAttribute.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace RaptorSheets.Core.Attributes;
 
 /// <summary>

--- a/RaptorSheets.Core/Attributes/SheetOrderAttribute.cs
+++ b/RaptorSheets.Core/Attributes/SheetOrderAttribute.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace RaptorSheets.Core.Attributes;
 
 /// <summary>

--- a/RaptorSheets.Core/Helpers/EntityColumnOrderHelper.cs
+++ b/RaptorSheets.Core/Helpers/EntityColumnOrderHelper.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using RaptorSheets.Core.Attributes;
 using RaptorSheets.Core.Models.Google;

--- a/RaptorSheets.Core/Helpers/EntitySheetConfigHelper.cs
+++ b/RaptorSheets.Core/Helpers/EntitySheetConfigHelper.cs
@@ -1,9 +1,5 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using RaptorSheets.Core.Attributes;
-using RaptorSheets.Core.Helpers;
 using RaptorSheets.Core.Models.Google;
 
 namespace RaptorSheets.Core.Helpers;

--- a/RaptorSheets.Core/Helpers/EntitySheetOrderHelper.cs
+++ b/RaptorSheets.Core/Helpers/EntitySheetOrderHelper.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using RaptorSheets.Core.Attributes;
 
@@ -35,11 +32,8 @@ public static class EntitySheetOrderHelper
             }
         }
 
-        // Sort by order and return sheet names
-        return sheetInfos
-            .OrderBy(info => info.Order)
-            .Select(info => info.SheetName)
-            .ToList();
+        // Return sheet names in the order properties are declared
+        return sheetInfos.Select(info => info.SheetName).ToList();
     }
 
     /// <summary>

--- a/RaptorSheets.Gig.Tests/Integration/Mappers/EntityColumnOrderIntegrationTests.cs
+++ b/RaptorSheets.Gig.Tests/Integration/Mappers/EntityColumnOrderIntegrationTests.cs
@@ -2,7 +2,6 @@
 using RaptorSheets.Gig.Constants;
 using RaptorSheets.Gig.Entities;
 using RaptorSheets.Gig.Mappers;
-using Xunit;
 
 namespace RaptorSheets.Gig.Tests.Integration.Mappers;
 

--- a/RaptorSheets.Gig.Tests/Integration/Mappers/EntityDrivenSheetsConfigIntegrationTests.cs
+++ b/RaptorSheets.Gig.Tests/Integration/Mappers/EntityDrivenSheetsConfigIntegrationTests.cs
@@ -2,7 +2,6 @@ using RaptorSheets.Core.Extensions;
 using RaptorSheets.Core.Helpers;
 using RaptorSheets.Gig.Constants;
 using RaptorSheets.Gig.Entities;
-using Xunit;
 
 namespace RaptorSheets.Gig.Tests.Integration.Mappers;
 

--- a/RaptorSheets.Gig.Tests/Integration/Mappers/SheetOrder_GetAllSheetNames_Tests.cs
+++ b/RaptorSheets.Gig.Tests/Integration/Mappers/SheetOrder_GetAllSheetNames_Tests.cs
@@ -1,6 +1,4 @@
 using RaptorSheets.Gig.Constants;
-using Xunit;
-using System.Collections.Generic;
 
 namespace RaptorSheets.Gig.Tests.Integration.Mappers;
 

--- a/RaptorSheets.Gig.Tests/Integration/Workflows/GoogleSheetIntegrationWorkflow.cs
+++ b/RaptorSheets.Gig.Tests/Integration/Workflows/GoogleSheetIntegrationWorkflow.cs
@@ -190,7 +190,7 @@ public class GoogleSheetIntegrationWorkflow : IAsyncLifetime
         System.Diagnostics.Debug.WriteLine($"Creating all gig sheets using default CreateSheets() method");
         
         // Use the default CreateSheets() method which creates all gig sheets from constants
-        var creationResult = await _googleSheetManager.CreateSheets();
+        var creationResult = await _googleSheetManager.CreateAllSheets();
         Assert.NotNull(creationResult);
 
         LogMessages("Create", creationResult.Messages);

--- a/RaptorSheets.Gig.Tests/Unit/Helpers/GigSheetConfigurationHelpersTests.cs
+++ b/RaptorSheets.Gig.Tests/Unit/Helpers/GigSheetConfigurationHelpersTests.cs
@@ -1,5 +1,4 @@
 using RaptorSheets.Core.Enums;
-using RaptorSheets.Core.Extensions;
 using RaptorSheets.Core.Models.Google;
 using RaptorSheets.Gig.Constants;
 using RaptorSheets.Gig.Enums;

--- a/RaptorSheets.Gig/Entities/ServiceEntity.cs
+++ b/RaptorSheets.Gig/Entities/ServiceEntity.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 using RaptorSheets.Core.Attributes;
 using RaptorSheets.Gig.Constants;

--- a/RaptorSheets.Gig/Entities/SheetEntity.cs
+++ b/RaptorSheets.Gig/Entities/SheetEntity.cs
@@ -1,5 +1,4 @@
 using RaptorSheets.Core.Entities;
-using RaptorSheets.Gig.Entities;
 using RaptorSheets.Core.Attributes;
 using RaptorSheets.Gig.Constants;
 using System.Text.Json.Serialization;

--- a/RaptorSheets.Gig/Helpers/GigSheetConfigurationHelpers.cs
+++ b/RaptorSheets.Gig/Helpers/GigSheetConfigurationHelpers.cs
@@ -2,7 +2,6 @@ using RaptorSheets.Core.Enums;
 using RaptorSheets.Core.Extensions;
 using RaptorSheets.Core.Models.Google;
 using RaptorSheets.Gig.Enums;
-using RaptorSheets.Gig.Constants;
 
 namespace RaptorSheets.Gig.Helpers;
 

--- a/RaptorSheets.Gig/Mappers/PlaceMapper.cs
+++ b/RaptorSheets.Gig/Mappers/PlaceMapper.cs
@@ -6,7 +6,6 @@ using RaptorSheets.Gig.Constants;
 using RaptorSheets.Gig.Entities;
 using RaptorSheets.Gig.Enums;
 using RaptorSheets.Gig.Helpers;
-using static RaptorSheets.Gig.Constants.SheetsConfig;
 
 namespace RaptorSheets.Gig.Mappers;
 


### PR DESCRIPTION
Changed sheet order logic to use property declaration order instead of attribute order. Refactored GoogleSheetManager to clarify and standardize method names (e.g., CreateSheets -> CreateAllSheets, GetSheets -> GetAllSheets, GetSheetProperties -> GetAllSheetProperties). Extracted and simplified logic for handling sheet changes and batch update requests. Updated tests and removed unused usings for consistency.