### PR TITLE
Update Gig package documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RaptorSheets.Core
 
-A comprehensive .NET 8 library that simplifies Google Sheets API interactions for developers who need powerful spreadsheet integration without the complexity. Build custom Google Sheets solutions or use our specialized packages for common use cases.
+A comprehensive .NET 8 library that simplifies Google Sheets API interactions for developers who need powerful spread| **[📋 Gig Package](RaptorSheets.Gig/README.md)** | Complete gig work tracking guide |heet integration without the complexity. Build custom Google Sheets solutions or use our specialized packages for common use cases.
 
 | Badge Name | Status | Site |
 | ---------- | :------------: | :------------: |
@@ -83,10 +83,10 @@ Built on RaptorSheets.Core, these packages provide domain-specific functionality
 
 | Package | Version | Purpose | Documentation |
 |---------|---------|---------|---------------|
-| **[RaptorSheets.Gig](https://www.nuget.org/packages/RaptorSheets.Gig/)** | [![Nuget](https://img.shields.io/nuget/v/RaptorSheets.Gig)](https://www.nuget.org/packages/RaptorSheets.Gig/) | Complete gig work tracking with automated analytics | **[📖 Gig Guide](docs/GIG.md)** |
+| **[RaptorSheets.Gig](https://www.nuget.org/packages/RaptorSheets.Gig/)** | [![Nuget](https://img.shields.io/nuget/v/RaptorSheets.Gig)](https://www.nuget.org/packages/RaptorSheets.Gig/) | Complete gig work tracking with automated analytics | **[📖 Gig Guide](RaptorSheets.Gig/README.md)** |
 | **RaptorSheets.Stock** *(Coming Soon)* | - | Investment portfolio tracking | - |
 
-> **Looking for gig work tracking?** Check out **[RaptorSheets.Gig](docs/GIG.md)** - a complete solution for freelancers and gig workers with pre-built sheets for trips, shifts, earnings, and comprehensive analytics.
+> **Looking for gig work tracking?** Check out **[RaptorSheets.Gig](RaptorSheets.Gig/README.md)** - a complete solution for freelancers and gig workers with pre-built sheets for trips, shifts, earnings, and comprehensive analytics.
 
 ## 📚 Core Library Overview
 
@@ -203,7 +203,7 @@ public class CustomManager
 // 3. Build specialized functionality on top of Core's foundation
 ```
 
-**See [RaptorSheets.Gig](docs/GIG.md) as a complete example of a specialized package built on Core.**
+**See [RaptorSheets.Gig](RaptorSheets.Gig/README.md) as a complete example of a specialized package built on Core.**
 
 ## 🛠️ Development Setup
 

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -471,5 +471,5 @@ If you're still having authentication issues:
 
 For more specific implementation guidance, see the package-specific documentation:
 - [Core Library](CORE.md) - For custom implementations
-- [Gig Package](GIG.md) - For gig work tracking
+- [Gig Package](../RaptorSheets.Gig/README.md) - For gig work tracking
 - [Stock Package](STOCK.md) - For portfolio management

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -185,9 +185,9 @@ var allData = await manager.GetSheets();
 - **[🧪 Testing](CORE.md#testing)** - Unit testing your integrations
 
 ### For RaptorSheets.Gig Users
-- **[📖 Gig Documentation](GIG.md)** - Complete feature guide
-- **[📊 Sheet Types](GIG.md#sheet-types)** - Understanding all available sheets
-- **[💡 Examples](GIG.md#examples)** - Real-world usage scenarios
+- **[📖 Gig Documentation](../RaptorSheets.Gig/README.md)** - Complete feature guide
+- **[📊 Sheet Types](../RaptorSheets.Gig/README.md#sheet-types)** - Understanding all available sheets
+- **[💡 Examples](../RaptorSheets.Gig/README.md#examples)** - Real-world usage scenarios
 
 ### For All Users
 - **[🔐 Authentication Details](AUTHENTICATION.md)** - Complete setup guide


### PR DESCRIPTION
Replaced references to docs/GIG.md with links to RaptorSheets.Gig/README.md in README.md, AUTHENTICATION.md, and GETTING-STARTED.md to reflect the new location of the Gig package documentation.