### PR TITLE
Refactor helper methods for conciseness and clarity

### DIFF
--- a/RaptorSheets.Core/Helpers/ConstantsOrderHelper.cs
+++ b/RaptorSheets.Core/Helpers/ConstantsOrderHelper.cs
@@ -19,15 +19,10 @@ public static class ConstantsOrderHelper
             .Where(f => f.IsLiteral && !f.IsInitOnly && f.FieldType == typeof(string))
             .ToList();
 
-        var result = new List<string>();
-        foreach (var field in fields)
-        {
-            if (field.GetValue(null) is string value)
-            {
-                result.Add(value);
-            }
-        }
-
+        var result = fields
+            .Select(field => field.GetValue(null))
+            .OfType<string>()
+            .ToList();
         return result;
     }
 

--- a/RaptorSheets.Core/Helpers/EntityColumnOrderHelper.cs
+++ b/RaptorSheets.Core/Helpers/EntityColumnOrderHelper.cs
@@ -30,7 +30,7 @@ public static class EntityColumnOrderHelper
         var allProperties = GetPropertiesInInheritanceOrder(entityType);
 
         // Process properties with ColumnOrder attributes
-        foreach (var property in allProperties)
+        foreach (var property in allProperties.Where(p => p.GetCustomAttribute<ColumnOrderAttribute>() != null))
         {
             var columnOrderAttr = property.GetCustomAttribute<ColumnOrderAttribute>();
             if (columnOrderAttr != null && processedHeaders.Add(columnOrderAttr.HeaderName))
@@ -97,7 +97,7 @@ public static class EntityColumnOrderHelper
 
         var allProperties = GetPropertiesInInheritanceOrder(entityType);
 
-        foreach (var property in allProperties)
+        foreach (var property in allProperties.Where(p => p.GetCustomAttribute<ColumnOrderAttribute>() != null))
         {
             var columnOrderAttr = property.GetCustomAttribute<ColumnOrderAttribute>();
             if (columnOrderAttr != null && !availableHeadersSet.Contains(columnOrderAttr.HeaderName))
@@ -137,16 +137,12 @@ public static class EntityColumnOrderHelper
         // Process properties from base classes first
         foreach (var type in typeHierarchy)
         {
-            var properties = type.GetProperties(BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.Instance);
-            
+            var properties = type.GetProperties(BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.Instance)
+                .Where(property => !processedProperties.Contains(property.Name));
             foreach (var property in properties)
             {
-                // Skip if we've already processed this property name (handles overrides)
-                if (!processedProperties.Contains(property.Name))
-                {
-                    orderedProperties.Add(property);
-                    processedProperties.Add(property.Name);
-                }
+                orderedProperties.Add(property);
+                processedProperties.Add(property.Name);
             }
         }
 

--- a/RaptorSheets.Core/Helpers/EntitySheetConfigHelper.cs
+++ b/RaptorSheets.Core/Helpers/EntitySheetConfigHelper.cs
@@ -52,12 +52,9 @@ public static class EntitySheetConfigHelper
         var entityHeaderNames = entityHeaders.Select(h => h.Name).ToHashSet();
 
         // Add additional headers that aren't already in the entity
-        foreach (var additionalHeader in additionalHeaders)
+        foreach (var additionalHeader in additionalHeaders.Where(h => !entityHeaderNames.Contains(h.Name)))
         {
-            if (!entityHeaderNames.Contains(additionalHeader.Name))
-            {
-                entityHeaders.Add(additionalHeader);
-            }
+            entityHeaders.Add(additionalHeader);
         }
 
         return entityHeaders;
@@ -77,13 +74,10 @@ public static class EntitySheetConfigHelper
         // Add headers from common patterns that aren't already in the entity
         foreach (var pattern in commonHeaderPatterns)
         {
-            foreach (var header in pattern)
+            foreach (var header in pattern.Where(h => !entityHeaderNames.Contains(h.Name)))
             {
-                if (!entityHeaderNames.Contains(header.Name))
-                {
-                    entityHeaders.Add(header);
-                    entityHeaderNames.Add(header.Name);
-                }
+                entityHeaders.Add(header);
+                entityHeaderNames.Add(header.Name);
             }
         }
 
@@ -115,12 +109,9 @@ public static class EntitySheetConfigHelper
         if (requiredHeaders != null)
         {
             var entityHeaderSet = entityHeaders.ToHashSet();
-            foreach (var requiredHeader in requiredHeaders)
+            foreach (var requiredHeader in requiredHeaders.Where(rh => !entityHeaderSet.Contains(rh)))
             {
-                if (!entityHeaderSet.Contains(requiredHeader))
-                {
-                    errors.Add($"Entity '{entityType.Name}' is missing required header '{requiredHeader}' with ColumnOrder attribute.");
-                }
+                errors.Add($"Entity '{entityType.Name}' is missing required header '{requiredHeader}' with ColumnOrder attribute.");
             }
         }
 
@@ -151,16 +142,12 @@ public static class EntitySheetConfigHelper
         // Process properties from base classes first
         foreach (var type in typeHierarchy)
         {
-            var properties = type.GetProperties(BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.Instance);
-            
+            var properties = type.GetProperties(BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.Instance)
+                .Where(property => !processedProperties.Contains(property.Name));
             foreach (var property in properties)
             {
-                // Skip if we've already processed this property name
-                if (!processedProperties.Contains(property.Name))
-                {
-                    orderedProperties.Add(property);
-                    processedProperties.Add(property.Name);
-                }
+                orderedProperties.Add(property);
+                processedProperties.Add(property.Name);
             }
         }
 

--- a/RaptorSheets.Core/Validators/SheetValidationHelpers.cs
+++ b/RaptorSheets.Core/Validators/SheetValidationHelpers.cs
@@ -12,7 +12,7 @@ public static class SheetValidationHelpers
     /// <summary>
     /// Validate that required parameters are not null or empty
     /// </summary>
-    public static List<MessageEntity> ValidateRequiredParameters(params (string value, string paramName)[] parameters)
+    public static List<MessageEntity> ValidateRequiredParameters(params (string? value, string paramName)[] parameters)
     {
         var messages = new List<MessageEntity>();
 


### PR DESCRIPTION
Simplified LINQ usage and filtering in helper methods across ConstantsOrderHelper, EntityColumnOrderHelper, and EntitySheetConfigHelper to reduce code duplication and improve readability. Updated property processing logic to use LINQ's Where for filtering and replaced manual loops with more concise expressions. Also updated ValidateRequiredParameters to accept nullable strings for improved null safety.