### PR TITLE
Preserve constant declaration order in GetOrderFromConstants

### DIFF
--- a/RaptorSheets.Core/Helpers/ConstantsOrderHelper.cs
+++ b/RaptorSheets.Core/Helpers/ConstantsOrderHelper.cs
@@ -14,11 +14,13 @@ public static class ConstantsOrderHelper
     /// </summary>
     /// <param name="constantsType">Type containing string constants (e.g., SheetsConfig.SheetNames)</param>
     /// <returns>List of constant values in declaration order</returns>
-    public static List<string> GetOrderFromConstants(Type constantsType)
+    public static List<string> GetOrderFromConstants(Type type)
     {
-        return constantsType.GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)
-            .Where(f => f.IsLiteral && !f.IsInitOnly && f.FieldType == typeof(string))
-            .Select(f => f.GetValue(null) as string)
+        return type
+            .GetFields(BindingFlags.Public | BindingFlags.Static)
+            .Where(f => f.IsLiteral && !f.IsInitOnly) // Only constants
+            .OrderBy(f => f.MetadataToken) // Ensures declaration order
+            .Select(f => f.GetValue(null)?.ToString())
             .Where(v => v != null)
             .ToList()!;
     }


### PR DESCRIPTION
This pull request updates the `GetOrderFromConstants` method in `ConstantsOrderHelper` to ensure that string constants are returned in their original declaration order. The method's parameter name was also simplified for clarity.

Improvements to constant retrieval:

* Modified `GetOrderFromConstants` to use `OrderBy(f => f.MetadataToken)` so that the returned list of constants matches their declaration order in the source code. This makes the method's behavior more predictable and reliable.
* Simplified the parameter name from `constantsType` to `type` for clarity and consistency.Updated GetOrderFromConstants to order fields by MetadataToken, ensuring the returned list matches the declaration order of string constants. Also simplified parameter naming and field selection logic.